### PR TITLE
fixed warning messege produced by gameday()

### DIFF
--- a/R/GameDay.R
+++ b/R/GameDay.R
@@ -269,7 +269,7 @@ xml2df <- function(xml_path, ...) {
   # remove any columns that don't have a name
   df <- df[ , !is.na(names(df))]
   # Check for extra columns that may have been appended as a result of a double-pipe delimiter.
-  if(length(df)==10) df <- dplyr::select(df, - one_of("X10"))
+  if("X10" %in% colnames(df)) df <- dplyr::select(df, - one_of("X10"))
 
   
   if (nrow(df) == 0) {


### PR DESCRIPTION
@beanumber Sorry, but this was driving me nuts (mainly because it was my mistake)! I was getting the following warning message when I ran `gameday()`.

```
> gd <- gameday()
gid_2012_08_12_atlmlb_nynmlb_1

Warning message:Unknown variables: `X10` 
```

So, I knew exactly where it was, so I fixed it. Just a one-line change.